### PR TITLE
Parting with empty message

### DIFF
--- a/hexchat/buffextras.py
+++ b/hexchat/buffextras.py
@@ -44,7 +44,10 @@ def privmsg(word, word_eol, userdata, attrs):
             # :nick!ident@host joined
             send("Join", nick, channel, userhost)
         elif _type == 'parted':
-            if args.startswith('with message: ['):
+            if args.endswith(']', 15):
+                # :nick!ident@host parted with message: []
+                send("Part", nick, userhost, channel)
+            elif args.startswith('with message: ['):
                 # :nick!ident@host parted with message: [bla bla]
                 send("Part with Reason", nick, userhost, channel,
                      args[15:-1])


### PR DESCRIPTION
Generating an "Part" event (without reason) in case there is no message supplied.

> When I have my client connected to ZNC, parts are OK:
> 08:00:00 *	AndrewBacon (andrewbacon@andrewbacon.boys.xchat.cz) has left
> 
> But it looks like this in playback:
> 08:01:00 <*buffextras>	AndrewBacon!andrewbacon@andrewbacon.boys.xchat.cz parted with message: []
> 
> Without my change:
> 08:02:00 *	AndrewBacon (andrewbacon@andrewbacon.boys.xchat.cz) has left ()
> 
> With my change:
> 08:03:00 *	AndrewBacon (andrewbacon@andrewbacon.boys.xchat.cz) has left

This might be server specific case or more likely "issue" on the ZNC side, because RAW log looks like this:

> [08:06:33] >> :AndrewBacon!andrewbacon@andrewbacon.boys.xchat.cz PART #4057684 :